### PR TITLE
[Refactor] 소비 저장 API 구조 변경

### DIFF
--- a/backend/src/main/java/backend/backend/controller/AuthController.java
+++ b/backend/src/main/java/backend/backend/controller/AuthController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/backend/backend/controller/ConsumptionController.java
+++ b/backend/src/main/java/backend/backend/controller/ConsumptionController.java
@@ -24,14 +24,17 @@ import org.springframework.web.bind.annotation.*;
 public class ConsumptionController {
     private final ConsumptionService consumptionService;
 
-    @Operation(summary = "소비 저장 기능", security = {@SecurityRequirement(name = "JWT")})
+    @Operation(summary = "소비 저장 기능", security = {@SecurityRequirement(name = "JWT")}, hidden = true)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "소비 내역 저장이 완료되었습니다.",
             content = @Content(mediaType = "apllication/json",
             schema = @Schema(implementation = ConsumptionsSaveResponse.class),
-            examples = @ExampleObject("{\n" +
-                    "\"message\": \"소비 내역 저장이 완료되었습니다.\",\n" +
-                    "}"))),
+            examples = @ExampleObject("""
+                    {
+                    "consumptionDTOList": [{"id": "2000", "category": "잡화", "name": "말보로레드", "amount": "4500", "quantity": "1"}, {"id": "2001", "category": "문구", "name": "컴퓨터용싸인펜", "amount": "1000", "quantity": "2"}],
+                    "message": "소비 내역 저장이 완료되었습니다."
+                    }
+                    """))),
 
             @ApiResponse(responseCode = "404", description = "해당하는 영수증이 없습니다.",
             content = @Content(mediaType = "application/json",
@@ -54,10 +57,9 @@ public class ConsumptionController {
     @PostMapping("/save")
     public ResponseEntity<ConsumptionsSaveResponse> consumptionSave(@AuthenticationPrincipal String email
             ,@RequestBody ConsumptionsSaveRequest request) {
-        consumptionService.save(email, request);
-        ConsumptionsSaveResponse consumptionsSaveResponse = ConsumptionsSaveResponse.builder()
-                .message("소비 내역 저장이 완료되었습니다.").build();
-        return ResponseEntity.ok(consumptionsSaveResponse);
+        ConsumptionsSaveResponse response = consumptionService.save(email, request);
+        response.setMessage("소비 내역 저장이 완료되었습니다.");
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "전체 기간 소비 분석", security = {@SecurityRequirement(name = "JWT")}, hidden = true)

--- a/backend/src/main/java/backend/backend/controller/FacadeController.java
+++ b/backend/src/main/java/backend/backend/controller/FacadeController.java
@@ -35,10 +35,10 @@ public class FacadeController {
             schema = @Schema(implementation = FacadeReceiptProcessResponse.class),
             examples = @ExampleObject("""
                     {
-                    "receiptId": "1024",
                     "date": "2015/11/19",
-                    "totalAmount": "4500",
-                    "items": [{"category": "잡화", "name": "말보로레드", "amount": "4500"}, {"category": "문구", "name": "컴퓨터용싸인펜", "amount": "500"}],
+                    "totalAmount": "5500",
+                    "store_name": "GS25",
+                    "consumptionDTOList": [{"id": "2000", "category": "잡화", "name": "말보로레드", "amount": "4500", "quantity": "1"}, {"id": "2001", "category": "문구", "name": "컴퓨터용싸인펜", "amount": "1000", "quantity": "2"}],
                     "message": "영수증 분석 및 소비 내역 저장이 완료 되었습니다."
                     }
                     """))),

--- a/backend/src/main/java/backend/backend/dto/consumption/model/ConsumptionDTO.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/ConsumptionDTO.java
@@ -1,0 +1,17 @@
+package backend.backend.dto.consumption.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ConsumptionDTO {
+    private Long id;
+    private String category;
+    private String name;
+    private Long amount;
+    private Long quantity;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/response/ConsumptionsSaveResponse.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/response/ConsumptionsSaveResponse.java
@@ -1,14 +1,17 @@
 package backend.backend.dto.consumption.response;
 
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import backend.backend.dto.consumption.model.ConsumptionDTO;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @Builder
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ConsumptionsSaveResponse {
+    private List<ConsumptionDTO> consumptionDTOList;
     private String message;
 }

--- a/backend/src/main/java/backend/backend/dto/facade/response/FacadeReceiptProcessResponse.java
+++ b/backend/src/main/java/backend/backend/dto/facade/response/FacadeReceiptProcessResponse.java
@@ -1,6 +1,8 @@
 package backend.backend.dto.facade.response;
 
 import backend.backend.dto.common.model.Item;
+import backend.backend.dto.consumption.model.ConsumptionDTO;
+import backend.backend.dto.consumption.response.ConsumptionsSaveResponse;
 import backend.backend.dto.receipt.response.ReceiptAnalyzeResponse;
 import lombok.*;
 
@@ -13,16 +15,16 @@ import java.util.List;
 @AllArgsConstructor
 public class FacadeReceiptProcessResponse {
     private String date;
-    private Long total_amount;
-    private List<Item> items;
-    private String message;
+    private Long totalAmount;
     private String store_name;
+    private List<ConsumptionDTO> consumptionDTOList;
+    private String message;
 
-    public static FacadeReceiptProcessResponse fromReceiptAnalyzeResponse(ReceiptAnalyzeResponse receiptAnalyzeResponse) {
+    public static FacadeReceiptProcessResponse fromReceiptAnalyzeAndConsumptionSaveResponse(ReceiptAnalyzeResponse receiptAnalyzeResponse, ConsumptionsSaveResponse consumptionsSaveResponse) {
         return FacadeReceiptProcessResponse.builder()
                 .date(receiptAnalyzeResponse.getDate())
-                .items(receiptAnalyzeResponse.getItems())
-                .total_amount(receiptAnalyzeResponse.getTotalAmount())
+                .consumptionDTOList(consumptionsSaveResponse.getConsumptionDTOList())
+                .totalAmount(receiptAnalyzeResponse.getTotalAmount())
                 .store_name(receiptAnalyzeResponse.getStoreName())
                 .build();
     }

--- a/backend/src/main/java/backend/backend/service/FacadeService.java
+++ b/backend/src/main/java/backend/backend/service/FacadeService.java
@@ -2,6 +2,7 @@ package backend.backend.service;
 
 import backend.backend.dto.auth.request.ReceiptAnalyzeRequest;
 import backend.backend.dto.consumption.request.ConsumptionsSaveRequest;
+import backend.backend.dto.consumption.response.ConsumptionsSaveResponse;
 import backend.backend.dto.facade.request.FacadeConsumptionsAnalyzeRequest;
 import backend.backend.dto.facade.response.FacadeConsumptionsAnalyzeResponse;
 import backend.backend.dto.facade.response.FacadeReceiptProcessResponse;
@@ -22,9 +23,9 @@ public class FacadeService {
         ConsumptionsSaveRequest consumptionsSaveRequest = ConsumptionsSaveRequest.fromReceiptAnalyzeResponse(receiptAnalyzeResponse);
         consumptionsSaveRequest.setAccess_url(accessUrl);
 
-        consumptionService.save(email, consumptionsSaveRequest);
+        ConsumptionsSaveResponse consumptionsSaveResponse = consumptionService.save(email, consumptionsSaveRequest);
 
-        return FacadeReceiptProcessResponse.fromReceiptAnalyzeResponse(receiptAnalyzeResponse);
+        return FacadeReceiptProcessResponse.fromReceiptAnalyzeAndConsumptionSaveResponse(receiptAnalyzeResponse, consumptionsSaveResponse);
     }
 
     public FacadeConsumptionsAnalyzeResponse consumptionsAnalyzeProcess(String email, Long year, Long month, Long day) {

--- a/backend/src/main/java/backend/backend/service/ReceiptService.java
+++ b/backend/src/main/java/backend/backend/service/ReceiptService.java
@@ -60,7 +60,7 @@ public class ReceiptService {
             3. items: 상품 목록 배열
             - category: 위 카테고리 목록 참조
             - name: 상품명
-            - amount: 상품 금액(숫자만)
+            - amount: 상품 금액(단가, 숫자만)
             - quantity: 상품 수량(숫자만)
             4. totalAmount: 총 구매액(숫자만)
             5. error: 가게 이름과 상품이 모두 없을 경우 true로 설정 이외에는 false


### PR DESCRIPTION
# 🚀요약
- 소비 상품에 대해 변경을 수행 할 수 있도록 응답 구조 변경

# 📝작업 내용
-   [ ] 상품의 id를 프론트에 전달하도록 수정
-   [ ] 소비 저장 API의 응답 구조 변경에 따라 영수증 분석 - 소비 저장 통합 API의 응답 구조 변경

# 🎸기타 (연관 이슈)
close #77 
