### PR TITLE
feat: 기간 내 일별 소비 분석 기능 추가

### DIFF
--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -3,7 +3,7 @@ http {
 
     server {
         listen 80;
-        server_name ec2-3-34-198-121.ap-northeast-2.compute.amazonaws.com;
+        server_name moneywise-backend.shop ec2-3-34-198-121.ap-northeast-2.compute.amazonaws.com;
 
         location / {
             if ($request_method = 'OPTIONS') {

--- a/backend/src/main/java/backend/backend/controller/AuthController.java
+++ b/backend/src/main/java/backend/backend/controller/AuthController.java
@@ -9,6 +9,7 @@ import backend.backend.exception.response.ErrorResponse;
 import backend.backend.security.jwt.JwtUtils;
 import backend.backend.service.AuthService;
 import backend.backend.service.UserService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/backend/src/main/java/backend/backend/controller/ConsumptionController.java
+++ b/backend/src/main/java/backend/backend/controller/ConsumptionController.java
@@ -245,10 +245,155 @@ public class ConsumptionController {
                                     }
                                     """)))
     })
-    @DeleteMapping("delete/one/{id}")
-    public ResponseEntity<ConsumptionsDeleteOneResponse> ConsumptionDeleteAll(@AuthenticationPrincipal String email, @PathVariable(name = "id") Long id) {
+    @DeleteMapping("/delete/one/{id}")
+    public ResponseEntity<ConsumptionsDeleteOneResponse> consumptionDeleteAll(@AuthenticationPrincipal String email, @PathVariable(name = "id") Long id) {
         ConsumptionsDeleteOneResponse response = consumptionService.deleteOne(email, id);
         response.setMessage("소비 내역이 삭제되었습니다.");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "특정 기간 소비 일별 분석", security = {@SecurityRequirement(name = "JWT")})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "2015년 11월의 일별 소비 분석이 완료되었습니다./2015년 11월 1일부터 10일 까지의 일별 소비 분석이 완료되었습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConsumptionsDailyAnalyzeResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "year과 month만 지정한 경우", value = """
+                                            {
+                                              "dailyList": [
+                                                {
+                                                  "totalAmount": 252300,
+                                                  "date": "2015-11-01",
+                                                  "byCategory": [
+                                                    {
+                                                      "name": "기타",
+                                                      "amount": 250000
+                                                    },
+                                                    {
+                                                      "name": "음료",
+                                                      "amount": 2300
+                                                    }
+                                                  ],
+                                                  "topExpenses": [
+                                                    {
+                                                      "name": "말보로레드보루",
+                                                      "amount": 250000
+                                                    }
+                                                  ],
+                                                  "storeExpenses": [
+                                                    {
+                                                      "name": "CU",
+                                                      "amount": 250000
+                                                    },
+                                                    {
+                                                      "name": "GS25",
+                                                      "amount": 2300
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "totalAmount": 4500,
+                                                  "date": "2015-11-20",
+                                                  "byCategory": [
+                                                    {
+                                                      "name": "기타",
+                                                      "amount": 4500
+                                                    }
+                                                  ],
+                                                  "topExpenses": [
+                                                    {
+                                                      "name": "말보로레드",
+                                                      "amount": 4500
+                                                    }
+                                                  ],
+                                                  "storeExpenses": [
+                                                    {
+                                                      "name": "GS25",
+                                                      "amount": 4500
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "message": "2015년 11월의 일별 소비 분석이 완료되었습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(name = "start_day와 last_day를 지정한 경우", value = """
+                                            {
+                                              "dailyList": [
+                                                {
+                                                  "totalAmount": 2300,
+                                                  "date": "2015-11-15",
+                                                  "byCategory": [
+                                                    {
+                                                      "name": "음료",
+                                                      "amount": 2300
+                                                    }
+                                                  ],
+                                                  "topExpenses": [
+                                                    {
+                                                      "name": "파워에이드",
+                                                      "amount": 2300
+                                                    }
+                                                  ],
+                                                  "storeExpenses": [
+                                                    {
+                                                      "name": "CU",
+                                                      "amount": 2300
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "totalAmount": 4500,
+                                                  "date": "2015-11-20",
+                                                  "byCategory": [
+                                                    {
+                                                      "name": "기타",
+                                                      "amount": 4500
+                                                    }
+                                                  ],
+                                                  "topExpenses": [
+                                                    {
+                                                      "name": "말보로레드",
+                                                      "amount": 4500
+                                                    }
+                                                  ],
+                                                  "storeExpenses": [
+                                                    {
+                                                      "name": "GS25",
+                                                      "amount": 4500
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "message": "2015년 11월 15일 부터 20일 까지의 일별 소비 분석이 완료되었습니다."
+                                            }
+                                            """)
+                            })),
+
+            @ApiResponse(responseCode = "500", description = "소비 분석에 실패했습니다.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject("""
+                                    {
+                                    "typeName": "DATABASE_ERROR",
+                                    "message": "소비 분석에 실패했습니다."
+                                    }
+                                    """)))
+    })
+    @GetMapping("/analyze/daily/{year}/{month}/{start_day}/{last_day}")
+    public ResponseEntity<ConsumptionsDailyAnalyzeResponse> consumptionDailyAnalyze(
+            @AuthenticationPrincipal String email,
+            @RequestParam(name = "year") Long year,
+            @RequestParam(name = "month") Long month,
+            @RequestParam(name = "start_day", required = false) Long startDay,
+            @RequestParam(name = "last_day", required = false) Long lastDay) {
+        ConsumptionsDailyAnalyzeResponse response = consumptionService.getDailyAnalyze(email, year, month, startDay, lastDay);
+        if (startDay == null || lastDay == null) {
+            response.setMessage(year + "년 " + month + "월의 일별 소비 분석이 완료되었습니다.");
+        } else {
+            response.setMessage(year + "년 " + month + "월 " + startDay + "일 부터 " + lastDay + "일 까지의 일별 소비 분석이 완료되었습니다.");
+        }
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/backend/backend/controller/HealthCheckController.java
+++ b/backend/src/main/java/backend/backend/controller/HealthCheckController.java
@@ -1,0 +1,16 @@
+package backend.backend.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Controller
+public class HealthCheckController {
+    @Hidden
+    @GetMapping("/healthcheck")
+    public ResponseEntity<String> healthcheck() {
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/ByCategory.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/ByCategory.java
@@ -1,14 +1,12 @@
 package backend.backend.dto.consumption.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Setter
 public class ByCategory {
     private String name;
     private Long amount;

--- a/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindByCategoryQueryDTO.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindByCategoryQueryDTO.java
@@ -1,0 +1,18 @@
+package backend.backend.dto.consumption.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyFindByCategoryQueryDTO {
+    private LocalDate date;
+    private String name;
+    private Long amount;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindStoreExpenseQueryDTO.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindStoreExpenseQueryDTO.java
@@ -1,0 +1,18 @@
+package backend.backend.dto.consumption.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyFindStoreExpenseQueryDTO {
+    private LocalDate date;
+    private String name;
+    private Long amount;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindTopExpenseQueryDTO.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/DailyFindTopExpenseQueryDTO.java
@@ -1,0 +1,18 @@
+package backend.backend.dto.consumption.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyFindTopExpenseQueryDTO {
+    private LocalDate date;
+    private String name;
+    private Long amount;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/DailyList.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/DailyList.java
@@ -1,0 +1,16 @@
+package backend.backend.dto.consumption.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class DailyList {
+    private Long totalAmount;
+    private String date;
+    private List<ByCategory> byCategory;
+    private List<TopExpense> topExpenses;
+    private List<StoreExpense> storeExpenses;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/DailySumAmountQueryDTO.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/DailySumAmountQueryDTO.java
@@ -1,0 +1,17 @@
+package backend.backend.dto.consumption.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailySumAmountQueryDTO {
+    LocalDate date;
+    Long totalAmount;
+}

--- a/backend/src/main/java/backend/backend/dto/consumption/model/TopExpense.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/model/TopExpense.java
@@ -1,14 +1,12 @@
 package backend.backend.dto.consumption.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Setter
 public class TopExpense {
     private String name;
     private Long amount;

--- a/backend/src/main/java/backend/backend/dto/consumption/response/ConsumptionsDailyAnalyzeResponse.java
+++ b/backend/src/main/java/backend/backend/dto/consumption/response/ConsumptionsDailyAnalyzeResponse.java
@@ -1,0 +1,15 @@
+package backend.backend.dto.consumption.response;
+
+
+import backend.backend.dto.consumption.model.DailyList;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ConsumptionsDailyAnalyzeResponse {
+    private List<DailyList> dailyList;
+    private String message;
+}

--- a/backend/src/main/java/backend/backend/repository/ConsumptionRepositoryCustom.java
+++ b/backend/src/main/java/backend/backend/repository/ConsumptionRepositoryCustom.java
@@ -1,8 +1,6 @@
 package backend.backend.repository;
 
-import backend.backend.dto.consumption.model.ByCategory;
-import backend.backend.dto.consumption.model.StoreExpense;
-import backend.backend.dto.consumption.model.TopExpense;
+import backend.backend.dto.consumption.model.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +13,12 @@ public interface ConsumptionRepositoryCustom {
     List<StoreExpense> findStoreExpenseByStoreName(String email, Long year, Long month, Long day);
 
     Optional<Long> sumAmountByEmail(String email, Long year, Long month, Long day);
+
+    List<DailySumAmountQueryDTO> dailySumAmountByEmail(String email, Long year, Long month, Long startDay, Long lastDay);
+
+    List<DailyFindByCategoryQueryDTO> dailyFindByCategoryAndEmail(String email, Long year, Long month, Long startDay, Long lastDay);
+
+    List<DailyFindTopExpenseQueryDTO> dailyFindTopExpenseByEmail(String email, Long year, Long month, Long startDay, Long lastDay);
+
+    List<DailyFindStoreExpenseQueryDTO> dailyFindStoreExpenseByStoreName(String email, Long year, Long month, Long startDay, Long lastDay);
 }

--- a/backend/src/main/java/backend/backend/security/config/SecurityConfig.java
+++ b/backend/src/main/java/backend/backend/security/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig{
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/auth/signup",
+                                "/healthcheck",
                                 "/auth/login/**",
                                 "/auth/validate",
                                 "/auth/refresh",

--- a/backend/src/main/java/backend/backend/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/backend/backend/security/jwt/JwtAuthenticationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
 
         return  path.startsWith("/auth/login/") ||
+                path.equals("/healthcheck") ||
                 path.equals("/auth/validate") ||
                 path.equals("/auth/signup") ||
                 path.equals("/auth/refresh") ||

--- a/backend/src/test/java/backend/backend/Repository/ConsumptionRepositoryTest.java
+++ b/backend/src/test/java/backend/backend/Repository/ConsumptionRepositoryTest.java
@@ -1,6 +1,7 @@
 package backend.backend.Repository;
 
 import backend.backend.dto.consumption.model.ByCategory;
+import backend.backend.dto.consumption.model.DailySumAmountQueryDTO;
 import backend.backend.dto.consumption.model.TopExpense;
 import backend.backend.repository.ConsumptionRepository;
 import backend.backend.repository.ConsumptionRepositoryImpl;
@@ -30,6 +31,15 @@ class ConsumptionRepositoryTest {
         List<TopExpense> result = consumptionRepository.findTopExpenseByEmail(email, null, null, null);
         for (int i = 0; i < result.size(); i++) {
             System.out.println("Category Result: " + result.get(i).getName() + ", " + result.get(i).getAmount());
+        }
+    }
+
+    @Test
+    void dailySumAmountByEmailTest() {
+        String email = "test@naver.com";
+        List<DailySumAmountQueryDTO> result = consumptionRepository.dailySumAmountByEmail(email, 2015L, 11L, 10L, 20L);
+        for (int i = 0; i < result.size(); i++) {
+            System.out.println(result.get(i).getDate() + ", " + result.get(i).getTotalAmount());
         }
     }
 }


### PR DESCRIPTION
# 🚀요약
- 특정 기간 내 일별 소비 분석을 수행하여 반환하는 기능 추가

# 📝작업 내용
-   [ ] year, month, start_day, last_day를 입력받아 해당 월 또는 특정 기간 사이의 소비 분석을 일별로 수행하여 제공하는 기능 추가

# 🎸기타 (연관 이슈)
close #81 
